### PR TITLE
run linux tests using buildrecall

### DIFF
--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -18,28 +18,53 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Download brr
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          TAG: 0.0.21
+        run: |
+          curl -L https://github.com/buildrecall/brr/releases/download/$TAG/brr-$TAG-x86_64-unknown-linux-musl -o /tmp/brr
+          sudo mv /tmp/brr /usr/bin/brr
+          sudo chmod +x /usr/bin/brr
+          brr -V
+      - if: matrix.os == 'ubuntu-latest'
+        env:
+          BUILDRECALL_API_KEY: ${{ secrets.BUILDRECALL_API_KEY }}
+        run: brr run test linux
+      - if: matrix.os == 'windows-latest'
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
-      - run: cargo test
+      - if: matrix.os == 'windows-latest'
+        run: cargo test
   clippy_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: clippy
-      - run: cargo clippy --tests --all-targets -- -D warnings
+      - name: Download brr
+        env:
+          TAG: 0.0.21
+        run: |
+          curl -L https://github.com/buildrecall/brr/releases/download/$TAG/brr-$TAG-x86_64-unknown-linux-musl -o /tmp/brr
+          sudo mv /tmp/brr /usr/bin/brr
+          sudo chmod +x /usr/bin/brr
+          brr -V
+      - run: brr run clippy linux
+        env:
+          BUILDRECALL_API_KEY: ${{ secrets.BUILDRECALL_API_KEY }}
   fmt_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt
-      - run: cargo fmt --all -- --check
+      - name: Download brr
+        env:
+          TAG: 0.0.21
+        run: |
+          curl -L https://github.com/buildrecall/brr/releases/download/$TAG/brr-$TAG-x86_64-unknown-linux-musl -o /tmp/brr
+          sudo mv /tmp/brr /usr/bin/brr
+          sudo chmod +x /usr/bin/brr
+          brr -V
+      - run: brr run fmt linux
+        env:
+          BUILDRECALL_API_KEY: ${{ secrets.BUILDRECALL_API_KEY }}

--- a/.github/workflows/synth.yml
+++ b/.github/workflows/synth.yml
@@ -17,4 +17,14 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - run: cargo +nightly test
+      - name: Download brr
+        env:
+          TAG: 0.0.21
+        run: |
+          curl -L https://github.com/buildrecall/brr/releases/download/$TAG/brr-$TAG-x86_64-unknown-linux-musl -o /tmp/brr
+          sudo mv /tmp/brr /usr/bin/brr
+          sudo chmod +x /usr/bin/brr
+          brr -V
+      - run: brr run test linux
+        env:
+          BUILDRECALL_API_KEY: ${{ secrets.BUILDRECALL_API_KEY }}

--- a/buildrecall.toml
+++ b/buildrecall.toml
@@ -1,0 +1,27 @@
+[project]
+name = 'synth'
+
+[jobs.test]
+run = '''
+rustup show
+cargo +nightly test
+'''
+
+[jobs.clippy]
+run = '''
+cargo clippy --tests --all-targets -- -D warnings
+'''
+
+[jobs.fmt]
+run = '''
+cargo fmt --all -- --check
+'''
+
+[containers.linux]
+image = "rust:1"
+persist = [
+    "/usr/local/cargo/registry",
+    "/usr/local/cargo/git",
+    # persist the nightly rust toolchain so it is not re-installed every build
+    "/usr/local/rustup",
+]


### PR DESCRIPTION
This is an exploratory PR to demonstrate using buildrecall to run the linux CI tests.

Here's an example of an incremental run of the synth-cargo-test action https://github.com/buildrecall/synth/actions/runs/1382870650, note the windows pathway is unchanged.

Buildrecall's configuration can be found in buildrecall.toml. Note that an API key is required for brr to run in the getsynth github org.

We're happy to help speed up other parts of the CI or your local dev using buildrecall as well!