### PR TITLE
Refactor: Remove async closure nightly feature

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(async_closure, map_first_last, box_patterns, error_iter, try_blocks)]
+#![feature(map_first_last, box_patterns, error_iter, try_blocks)]
 #![allow(type_alias_bounds)]
 
 #[macro_export]

--- a/synth/src/lib.rs
+++ b/synth/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(async_closure, map_first_last, box_patterns, concat_idents, error_iter)]
+#![feature(map_first_last, box_patterns, concat_idents, error_iter)]
 #![allow(type_alias_bounds)]
 
 #[macro_use]


### PR DESCRIPTION
I didn't see async closures anywhere in the code, so I removed the declaration. Works toward #345.