### PR TITLE
fix: telemetry, bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "synth"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-std",

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synth"
-version = "0.6.6"
+version = "0.6.7"
 authors = [
   "Damien Broka <damien@getsynth.com>",
   "Christos Hadjiaslanis <christos@getsynth.com>",

--- a/synth/src/cli/telemetry.rs
+++ b/synth/src/cli/telemetry.rs
@@ -17,7 +17,6 @@ use uuid::Uuid;
 use crate::cli::export::ExportStrategy;
 use crate::cli::{config, GenerateCommand, ImportCommand};
 use crate::sampler::SamplerOutput;
-use crate::utils::META_OS;
 use crate::version::version;
 
 use synth_core::{


### PR DESCRIPTION
The telemetry features is untested, so a typo caused an error during the previous release.