### PR TITLE
refactor: Remove concat_idents

### DIFF
--- a/synth/src/lib.rs
+++ b/synth/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(map_first_last, box_patterns, concat_idents, error_iter)]
+#![feature(map_first_last, box_patterns, error_iter)]
 #![allow(type_alias_bounds)]
 
 #[macro_use]


### PR DESCRIPTION
One more step on the way to move to stable, #345.