### PR TITLE
Feat: Enable setting the install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ We are currently in Public Alpha. Watch "releases" of this repo to get notified 
 On Linux and MacOS you can get started with the one-liner:
 
 ```bash
+# Optional, set install path
+$ export SYNTH_INSTALL_PATH=~/bin
 $ curl -sSL https://getsynth.com/install | sh
 ```
 

--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -18,6 +18,10 @@ curl --proto '=https' --tlsv1.2 -sSL https://getsynth.com/install | sh
 ```
 
 :::note
+Change the path Synth is installed to set the `SYNTH_INSTALL_PATH` env variable
+:::
+
+:::note
 To skip the telemetry prompt (if you are installing Synth in CI for example) you can use the `--ci` flag.
 :::
 
@@ -90,6 +94,10 @@ Run the following command to install the `synth` binary:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSL https://getsynth.com/install | sh
 ```
+
+:::note
+Change the path Synth is installed to set the `SYNTH_INSTALL_PATH` env variable
+:::
 
 :::note
 To skip the telemetry prompt (if you are installing Synth in CI for example) you can use the `--ci` flag.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -36,7 +36,7 @@ main() {
 install_based_on_os() {
   case "$(uname)" in
   "Linux")
-    HOME_LOCAL_BIN="$HOME/.local/bin"
+    HOME_LOCAL_BIN="${SYNTH_INSTALL_PATH:-$HOME/.local/bin}"
 
     # Assuming [ ${GLIBC_MAJOR} -e 2 ]...
     GLIBC_MINOR=$(ldd --version 2>/dev/null | head -n1 | grep -o -e "[0-9]\{2\}$")
@@ -67,7 +67,7 @@ install_based_on_os() {
 
     ;;
   "Darwin")
-    HOME_LOCAL_BIN="/usr/local/bin"
+    HOME_LOCAL_BIN="${SYNTH_INSTALL_PATH:-/usr/local/bin}"
 
     os="latest"
 


### PR DESCRIPTION
On mac `/usr/local/bin` is owned by root an may lead people to sudo or chown. Enable users to specify install path.