### PR TITLE
fix: change the location of install.sh

### DIFF
--- a/www/vercel.json
+++ b/www/vercel.json
@@ -20,7 +20,7 @@
     },
     {
       "source": "/static/releases/latest/install.sh",
-      "destination": "https://storage.googleapis.com/getsynth-public/install/install.sh"
+      "destination": "https://raw.githubusercontent.com/shuttle-hq/synth/master/tools/install.sh"
     },
     {
       "source": "/static/releases/latest/:file",


### PR DESCRIPTION
On #387 it was noticed that the install.sh on the website was not getting updated. This PR makes the website use the github asset.