### PR TITLE
chore: remove most uses of actions-rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
         - ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
+    - uses: dtolnay/toolchain@nightly
     - id: tag
       uses: dawidd6/action-get-tag@v1
     - run: cargo build --release --features telemetry --bin synth
@@ -88,9 +86,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - id: tag
       uses: dawidd6/action-get-tag@v1
     - run: cargo build --release --features telemetry --bin synth
@@ -107,9 +103,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - id: tag
         uses: dawidd6/action-get-tag@v1
       - id: version

--- a/.github/workflows/synth-bench.yml
+++ b/.github/workflows/synth-bench.yml
@@ -17,9 +17,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends valgrind
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: actions/setup-python@v2
     - name: run benchmark
       id: bench

--- a/.github/workflows/synth-errors.yml
+++ b/.github/workflows/synth-errors.yml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/toolchain@nightly
       - run: cargo +nightly install --locked --debug --path=synth
       - run: ./e2e.sh
         working-directory: synth/testing_harness/errors

--- a/.github/workflows/synth-mongo.yml
+++ b/.github/workflows/synth-mongo.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           docker run -p $PORT:27017 --name mongo-synth-harness -d mongo:latest
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/toolchain@nightly
       - run: cargo install --locked --debug --path=synth
       - run: ./e2e.sh test-generate
         working-directory: synth/testing_harness/mongodb

--- a/.github/workflows/synth-mysql.yml
+++ b/.github/workflows/synth-mysql.yml
@@ -59,9 +59,7 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends jq
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install --locked --debug --path=synth
       - run: ./e2e.sh test-generate
         working-directory: synth/testing_harness/mysql

--- a/.github/workflows/synth-postgres.yml
+++ b/.github/workflows/synth-postgres.yml
@@ -36,9 +36,7 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends jq
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install --locked --debug --path=synth
       - run: ./e2e.sh test-generate
         working-directory: synth/testing_harness/postgres

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -18,26 +18,21 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo test
   clippy_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: clippy
       - run: cargo clippy --tests --all-targets -- -D warnings
   fmt_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/.github/workflows/synth.yml
+++ b/.github/workflows/synth.yml
@@ -14,7 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo test


### PR DESCRIPTION
Addresses #399. There is still one use of actions-rs left, for using cross, but I haven't found any alternative.