### PR TITLE
fix: Fix panic during CSV import when encountering invalid floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,16 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,11 +2010,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if 1.0.0",
  "serde",
  "value-bag",
 ]
@@ -3502,11 +3491,70 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sval"
-version = "1.0.0-alpha.5"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
+checksum = "0e6aa16ce8d9e472e21a528a52c875a76a49190f3968f2ec7e9b550ccc28b410"
+
+[[package]]
+name = "sval_buffer"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905c4373621186ee9637464b0aaa026389ea9e7f841f2225f160a32ba5d5bac4"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6b4988322c5f22859a6a7649fa1249aa3dd01514caf8ed57d83735f997bb8b"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3ccd10346f925c2fbd97b75e8573b38e34431bfba04cc531cd23aad0fbabb8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a12e1488defd6344e23243c17ea4a1b185c547968749e8a281373fde0bde2d5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b797fc4b284dd0e45f7ec424479e604ea5be9bb191a1ef4e96c20c7685649938"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810fa9a837e67a23e0efa7536250fc4d24043306cc1efd076f1943ba2fc2e62d"
 dependencies = [
  "serde",
+ "sval",
+ "sval_buffer",
+ "sval_fmt",
 ]
 
 [[package]]
@@ -4109,16 +4157,38 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 dependencies = [
- "ctor",
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4735c95b4cca1447b448e2e2e87e98d7e7498f4da27e355cf7af02204521001d"
+dependencies = [
  "erased-serde",
  "serde",
  "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859cb4f0ce7da6a118b559ba74b0e63bf569bea867c20ba457a6b1c886a04e97"
+dependencies = [
  "sval",
- "version_check",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
 ]
 
 [[package]]

--- a/core/src/graph/number.rs
+++ b/core/src/graph/number.rs
@@ -495,6 +495,7 @@ pub mod test {
             overflowed: false,
         };
 
+        #[allow(clippy::default_constructed_unit_structs)]
         let mut rng = OsRng::default();
 
         for i in 0..255 {

--- a/core/src/schema/content/number.rs
+++ b/core/src/schema/content/number.rs
@@ -531,9 +531,7 @@ impl RangeStep<u64> {
 impl Categorical<u64> {
     pub fn upcast(self, to: NumberContentKind) -> Result<NumberContent> {
         match to {
-            NumberContentKind::U64 => {
-                Ok(number_content::U64::Categorical(self).into())
-            }
+            NumberContentKind::U64 => Ok(number_content::U64::Categorical(self).into()),
             NumberContentKind::I64 => {
                 let cast = Categorical {
                     seen: self
@@ -543,12 +541,15 @@ impl Categorical<u64> {
                             i64::try_from(k)
                                 .map(|k_cast| (k_cast, v))
                                 .map_err(|err| err.into())
-                        }).collect::<Result<_>>()?,
+                        })
+                        .collect::<Result<_>>()?,
                     total: self.total,
                 };
                 Ok(number_content::I64::Categorical(cast).into())
             }
-            NumberContentKind::F64 => Err(failed!(target: Release, "cannot upcast categorical subtypes to accept floats; try changing this another numerical subtype manually"))
+            NumberContentKind::F64 => Err(
+                failed!(target: Release, "cannot upcast categorical subtypes to accept floats; try changing this another numerical subtype manually"),
+            ),
         }
     }
 }
@@ -611,7 +612,9 @@ impl Categorical<i64> {
                 Err(failed!(target: Release, "cannot downcast numerical subtypes"))
             }
             NumberContentKind::I64 => Ok(number_content::I64::Categorical(self).into()),
-            NumberContentKind::F64 => Err(failed!(target: Release, "cannot upcast categorical subtypes to accept floats; try changing this another numerical subtype manually")),
+            NumberContentKind::F64 => Err(
+                failed!(target: Release, "cannot upcast categorical subtypes to accept floats; try changing this another numerical subtype manually"),
+            ),
         }
     }
 }

--- a/core/src/schema/optionalise.rs
+++ b/core/src/schema/optionalise.rs
@@ -21,32 +21,37 @@ impl OptionaliseApi for Namespace {
     fn optionalise(&mut self, optionalise: Optionalise) -> Result<()> {
         let target = optionalise.at;
         match target.parent() {
-            Some(parent) => {
-                match self.get_s_node_mut(&parent)? {
-                    Content::Object(object_content) |
-                    Content::Array(ArrayContent { content: box Content::Object(object_content), .. }) => {
-                        let fc = object_content.get_mut(&target.last())?;
-                        let owned = std::mem::replace(fc, Content::null());
-                        *fc = if optionalise.optional {
-                            owned.into_nullable()
-                        } else if owned.is_nullable() {
-                            match owned {
-                                Content::OneOf(OneOfContent { variants }) => {
-                                    variants.into_iter().map(|vc| *vc.content).find(|v| !v.is_null()).unwrap()
-                                }
-                                _ => unreachable!()
-                            }
-                        } else {
-                            owned
-                        };
-                        Ok(())
-                    }
-                    otherwise => Err(failed!(target: Release, "Only fields of objects can be optional. But the reference '{}' (whose parent is '{}') is contained in a content node of type '{}'.", target, parent, otherwise.kind()))
+            Some(parent) => match self.get_s_node_mut(&parent)? {
+                Content::Object(object_content)
+                | Content::Array(ArrayContent {
+                    content: box Content::Object(object_content),
+                    ..
+                }) => {
+                    let fc = object_content.get_mut(&target.last())?;
+                    let owned = std::mem::replace(fc, Content::null());
+                    *fc = if optionalise.optional {
+                        owned.into_nullable()
+                    } else if owned.is_nullable() {
+                        match owned {
+                            Content::OneOf(OneOfContent { variants }) => variants
+                                .into_iter()
+                                .map(|vc| *vc.content)
+                                .find(|v| !v.is_null())
+                                .unwrap(),
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        owned
+                    };
+                    Ok(())
                 }
-            }
-            None => {
-                Err(failed!(target: Release, "Field '{}' is top-level (meaning it just references a collection). Top-level fields cannot be made optional.", target))
-            }
+                otherwise => Err(
+                    failed!(target: Release, "Only fields of objects can be optional. But the reference '{}' (whose parent is '{}') is contained in a content node of type '{}'.", target, parent, otherwise.kind()),
+                ),
+            },
+            None => Err(
+                failed!(target: Release, "Field '{}' is top-level (meaning it just references a collection). Top-level fields cannot be made optional.", target),
+            ),
         }
     }
 }

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = "1.0.32"
 
 structopt = "0.3.18"
 
-log = "0.4.11"
+log = "0.4.18"
 env_logger = "0.7.1"
 
 num_cpus = "1.0"


### PR DESCRIPTION
This fix will address #432, which was caused by an unchecked `unwrap()` after trying to convert a F64 value to a JSON Number. Since JSON Numbers cannot wrap `NaN` or `Inf` values, this would previously fail if encountering a string of the form `"Nan"` or `"Inf"`

Additionally, this change bumps up the version of the `log` dependency in `synth/Cargo.toml` from `0.4.11` to `0.4.18` to fix a compilation issue on recent nightly toolchains (see [this issue in async-std for more info](https://github.com/async-rs/async-std/issues/1058))