### PR TITLE
fix: versions for GH actions are behind

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -12,9 +12,9 @@ jobs:
     name: synth public cachix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install nix
-        uses: cachix/install-nix-action@v16
+        uses: cachix/install-nix-action@v20
       - name: Setup cachix
         uses: cachix/cachix-action@v12
         with:


### PR DESCRIPTION
Cachix is still failing, this might fix it. #434.