### PR TITLE
Implement `i8` and detect types correctly in MySQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -43,18 +43,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -82,15 +82,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-attributes"
@@ -115,13 +115,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.0.0",
- "event-listener-strategy 0.5.0",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
@@ -177,21 +176,21 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.3.0",
  "parking",
- "polling 3.4.0",
- "rustix 0.38.31",
+ "polling 3.7.3",
+ "rustix 0.38.36",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -205,12 +204,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -227,26 +226,26 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.31",
+ "rustix 0.38.36",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.1",
- "async-lock 2.8.0",
+ "async-io 2.3.4",
+ "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.31",
+ "rustix 0.38.36",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -294,19 +293,19 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -325,16 +324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic-write-file"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
-dependencies = [
- "nix",
- "rand",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,15 +336,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -391,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a143066d3cbd3d32c15b51c39449e50e32a68293d31589fb941d6a9df0df4f"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
 ]
 
 [[package]]
@@ -411,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -423,9 +412,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -453,25 +442,22 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.2.0",
- "async-lock 3.3.0",
+ "async-channel 2.3.1",
  "async-task",
- "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.3.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
 name = "bloomfilter"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64d54e47a7f4fd723f082e8f11429f3df6ba8adaeca355a76556f9f0602bbcf"
+checksum = "bc0bdbcf2078e0ba8a74e1fe0cf36f54054a04485759b61dfd60b174658e9607"
 dependencies = [
  "bit-vec",
  "getrandom",
@@ -480,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -490,25 +476,25 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
 [[package]]
 name = "bson"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce21468c1c9c154a85696bb25c20582511438edb6ad67f846ba1378ffdd80222"
+checksum = "d8a88e82b9106923b5c4d6edfca9e7db958d4e98a478ec115022e81b9b38e2c8"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.11",
  "base64 0.13.1",
  "bitvec",
  "chrono",
@@ -521,14 +507,14 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "time",
- "uuid 1.7.0",
+ "uuid 1.10.0",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
  "serde",
@@ -536,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecheck"
@@ -570,15 +556,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.0.85"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -588,15 +577,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -604,7 +593,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -624,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -681,24 +670,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
@@ -739,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -776,12 +765,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.2"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
  "nix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -821,15 +810,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -858,15 +847,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
- "syn 1.0.109",
+ "rustc_version 0.4.1",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -923,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
 ]
@@ -938,9 +927,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -987,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1025,20 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1047,21 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 4.0.3",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
-dependencies = [
- "event-listener 5.0.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1086,15 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "flume"
@@ -1104,7 +1066,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -1214,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1230,7 +1192,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1275,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1288,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "globset"
@@ -1302,7 +1264,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1319,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1347,11 +1309,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -1361,7 +1323,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1393,9 +1355,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1443,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1465,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1502,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1517,7 +1485,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1612,12 +1580,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1634,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1647,7 +1615,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1658,7 +1626,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1680,25 +1648,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1714,18 +1673,18 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -1735,13 +1694,12 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1769,15 +1727,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1785,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
@@ -1825,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1843,29 +1801,30 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "mongodb"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de59562e5c71656c098d8e966641b31da87b89dc3dcb6e761d3b37dcdfa0cb72"
+checksum = "ef206acb1b72389b49bc9985efe7eb1f8a9bb18e5680d262fac26c07f44025f1"
 dependencies = [
  "async-executor",
  "async-std",
@@ -1906,18 +1865,19 @@ dependencies = [
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder",
- "uuid 1.7.0",
+ "uuid 1.10.0",
  "webpki-roots",
 ]
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1942,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1956,11 +1916,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
  "rand",
@@ -1985,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
  "rand",
@@ -2010,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2021,11 +1980,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2033,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2047,7 +2005,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2059,9 +2017,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2097,9 +2055,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2107,22 +2065,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2150,9 +2108,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2162,12 +2120,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.1",
+ "fastrand 2.1.1",
  "futures-io",
 ]
 
@@ -2194,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
@@ -2216,16 +2174,17 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.4.0"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.31",
+ "rustix 0.38.36",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2248,15 +2207,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
 ]
@@ -2287,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2328,9 +2290,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2383,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2403,18 +2365,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2423,25 +2385,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2452,9 +2414,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rend"
@@ -2467,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2518,23 +2480,24 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2545,14 +2508,14 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.7.0",
+ "uuid 1.10.0",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2581,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2597,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -2612,11 +2575,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.21",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -2645,22 +2608,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -2689,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2735,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "semver-parser"
@@ -2747,41 +2710,42 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2854,10 +2818,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2880,9 +2850,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "siphasher"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2895,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -2911,19 +2881,13 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2946,20 +2910,19 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
- "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2970,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.11",
  "async-io 1.13.0",
  "async-std",
  "atoi",
@@ -2983,7 +2946,6 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
- "dotenvy",
  "either",
  "event-listener 2.5.3",
  "futures-channel",
@@ -3015,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3028,12 +2990,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "async-std",
- "atomic-write-file",
  "dotenvy",
  "either",
  "heck 0.4.1",
@@ -3055,13 +3016,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3099,13 +3060,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3128,7 +3089,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -3140,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -3164,13 +3124,13 @@ dependencies = [
 
 [[package]]
 name = "stringprep"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
 dependencies = [
- "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -3211,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3228,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3246,7 +3206,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3286,7 +3246,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust_decimal",
- "semver 1.0.21",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "sqlx",
@@ -3393,14 +3353,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "rustix 0.38.31",
- "windows-sys 0.52.0",
+ "fastrand 2.1.1",
+ "once_cell",
+ "rustix 0.38.36",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3444,29 +3405,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3485,9 +3446,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3495,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3510,41 +3471,40 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenstream2-tmpl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf48a946556c35fd2c2332204b5502d50376c1f11e36c707d3cd3a2aad40a6e"
+checksum = "4c980111e734582b1bbad9b1693cdc41c9c470d8a5ddc55a9c79e745cd0edb96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3559,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3569,20 +3529,19 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3591,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3615,7 +3574,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3709,12 +3668,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3724,9 +3689,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode_categories"
@@ -3752,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
@@ -3778,9 +3743,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
@@ -3788,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "vcpkg"
@@ -3806,21 +3771,21 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3842,35 +3807,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
+name = "wasite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3880,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3890,28 +3862,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3925,15 +3897,19 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
 
 [[package]]
 name = "widestring"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -3953,11 +3929,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3972,7 +3948,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3990,7 +3966,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4010,17 +3995,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4031,9 +4017,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4043,9 +4029,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4055,9 +4041,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4067,9 +4059,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4079,9 +4071,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4091,9 +4083,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4103,15 +4095,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -4137,26 +4129,27 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arrayvec"
@@ -187,7 +187,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -226,7 +226,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "windows-sys 0.48.0",
 ]
 
@@ -242,7 +242,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -342,17 +342,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a88e82b9106923b5c4d6edfca9e7db958d4e98a478ec115022e81b9b38e2c8"
+checksum = "80cf6f7806607bd58ad490bab34bf60e25455ea4aaf995f897a13324d41ea580"
 dependencies = [
  "ahash 0.8.11",
  "base64 0.13.1",
@@ -562,9 +562,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.16"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
 dependencies = [
  "shlex",
 ]
@@ -1250,15 +1250,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1514,9 +1514,9 @@ checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "itertools"
@@ -1801,11 +1801,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -2049,9 +2049,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2182,7 +2182,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2608,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3360,7 +3360,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "windows-sys 0.59.0",
 ]
 
@@ -3539,9 +3539,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3662,15 +3662,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -3683,9 +3683,9 @@ checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/core/src/graph/number.rs
+++ b/core/src/graph/number.rs
@@ -51,6 +51,7 @@ macro_rules! any_range_int_impl {
     }
 }
 
+any_range_int_impl! { u8 }
 any_range_int_impl! { u16 }
 any_range_int_impl! { u32 }
 any_range_int_impl! { u64 }
@@ -219,6 +220,7 @@ macro_rules! standard_int_range_step_impl {
     }
 }
 
+standard_int_range_step_impl! { i8, i16, u8}
 standard_int_range_step_impl! { i16, i32, u16}
 standard_int_range_step_impl! { i32, i64, u32 }
 standard_int_range_step_impl! { u32, u32, u32 }
@@ -480,6 +482,12 @@ number_node!(
         I16Categorical as categorical,
         Incrementing as incrementing,
     ) for i16,
+    RandomI8 (
+        I8Range<StandardIntRangeStep<u8, i16>> as range,
+        I8Constant as constant,
+        I8Categorical as categorical,
+        Incrementing as incrementing,
+    ) for i8,
 );
 
 #[cfg(test)]

--- a/core/src/schema/content/array.rs
+++ b/core/src/schema/content/array.rs
@@ -112,6 +112,15 @@ impl<'de> Deserialize<'de> for ArrayContent {
                             r.low .unwrap_or_default() .into(),
                         ).map_err(A::Error::custom)?
                     },
+                    Content::Number(NumberContent::I8(number_content::I8::Range(r))) => {
+                        if r.high.is_none() {
+                            return Err(A::Error::custom("missing high value for array length range"));
+                        }
+
+                        is_positive(
+                            r.low .unwrap_or_default() .into(),
+                        ).map_err(A::Error::custom)?
+                    },
                     Content::SameAs(_) => {},
                     Content::Null(_) => return Err(de::Error::custom("array length is missing. Try adding '\"length\": [number]' to the array type where '[number]' is a positive integer")),
                     Content::Empty(_) => return Err(de::Error::custom("array length is not a constant or number type. Try replacing the '\"length\": {}' with '\"length\": [number]' where '[number]' is a positive integer")),

--- a/core/src/schema/content/number.rs
+++ b/core/src/schema/content/number.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use super::Categorical;
 
-use crate::graph::number::{RandomF32, RandomI8, RandomI16, RandomI32, RandomU32};
+use crate::graph::number::{RandomF32, RandomI16, RandomI32, RandomI8, RandomU32};
 use serde::{ser::Serializer, Serialize};
 
 #[derive(Clone, Copy)]

--- a/core/src/schema/content/number.rs
+++ b/core/src/schema/content/number.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use super::Categorical;
 
-use crate::graph::number::{RandomF32, RandomI16, RandomI32, RandomU32};
+use crate::graph::number::{RandomF32, RandomI8, RandomI16, RandomI32, RandomU32};
 use serde::{ser::Serializer, Serialize};
 
 #[derive(Clone, Copy)]
@@ -205,6 +205,7 @@ impl NumberContent {
         match self {
             NumberContent::U32(_) => Ok(Self::u32_default_id()),
             NumberContent::U64(_) => Ok(Self::u64_default_id()),
+            NumberContent::I8(_) => Ok(Self::i8_default_id()),
             NumberContent::I16(_) => Ok(Self::i16_default_id()),
             NumberContent::I32(_) => Ok(Self::i32_default_id()),
             NumberContent::I64(_) => Ok(Self::i64_default_id()),
@@ -219,6 +220,10 @@ impl NumberContent {
 
     pub fn u64_default_id() -> Self {
         NumberContent::U64(number_content::U64::Id(Id::default()))
+    }
+
+    pub fn i8_default_id() -> Self {
+        NumberContent::I8(number_content::I8::Id(Id::default()))
     }
 
     pub fn i16_default_id() -> Self {
@@ -372,7 +377,7 @@ macro_rules! derive_hash {
     };
 }
 
-derive_hash!(i16, i32, u32, i64, u64, f32, f64);
+derive_hash!(i8, i16, i32, u32, i64, u64, f32, f64);
 
 number_content!(
     #[derive(PartialEq, Hash)]
@@ -388,6 +393,13 @@ number_content!(
         Categorical(Categorical<u64>),
         Constant(u64),
         Id(crate::schema::Id<u64>),
+    },
+    #[derive(PartialEq, Hash)]
+    i8[is_i8, default_i8_range] as I8 {
+        Range(RangeStep<i8>),
+        Categorical(Categorical<i8>),
+        Constant(i8),
+        Id(crate::schema::Id<i8>),
     },
     #[derive(PartialEq, Hash)]
     i16[is_i16, default_i16_range] as I16 {
@@ -489,6 +501,19 @@ impl Compile for NumberContent {
                     number_content::F32::Constant(val) => RandomF32::constant(*val),
                 };
                 random_f32.into()
+            }
+            Self::I8(i8_content) => {
+                let random_i8 = match i8_content {
+                    number_content::I8::Range(range) => RandomI8::range(*range)?,
+                    number_content::I8::Categorical(categorical_content) => {
+                        RandomI8::categorical(categorical_content.clone())
+                    }
+                    number_content::I8::Constant(val) => RandomI8::constant(*val),
+                    number_content::I8::Id(id) => {
+                        RandomI8::incrementing(Incrementing::new_at(id.start_at.unwrap_or(1)))
+                    }
+                };
+                random_i8.into()
             }
             Self::I16(i16_content) => {
                 let random_i16 = match i16_content {

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -15,7 +15,7 @@ use super::{
     Content, DateTimeContent, Id, NumberContent, NumberKindExt, ObjectContent, OneOfContent,
     RangeStep, StringContent, ValueKindExt,
 };
-use crate::graph::prelude::content::number_content::{I8, I16, I32, I64};
+use crate::graph::prelude::content::number_content::{I16, I32, I64, I8};
 use crate::schema::UniqueContent;
 use num::Zero;
 

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -15,7 +15,7 @@ use super::{
     Content, DateTimeContent, Id, NumberContent, NumberKindExt, ObjectContent, OneOfContent,
     RangeStep, StringContent, ValueKindExt,
 };
-use crate::graph::prelude::content::number_content::{I16, I32, I64};
+use crate::graph::prelude::content::number_content::{I8, I16, I32, I64};
 use crate::schema::UniqueContent;
 use num::Zero;
 
@@ -335,6 +335,17 @@ impl MergeStrategy<number_content::I16, i16> for OptionalMergeStrategy {
     }
 }
 
+impl MergeStrategy<number_content::I8, i8> for OptionalMergeStrategy {
+    fn try_merge(self, master: &mut number_content::I8, candidate: &i8) -> Result<()> {
+        match master {
+            number_content::I8::Range(range) => self.try_merge(range, candidate),
+            number_content::I8::Categorical(cat) => self.try_merge(cat, candidate),
+            number_content::I8::Constant(cst) => self.try_merge(cst, candidate),
+            I8::Id(id) => self.try_merge(id, candidate),
+        }
+    }
+}
+
 impl MergeStrategy<NumberContent, Number> for OptionalMergeStrategy {
     fn try_merge(self, master: &mut NumberContent, value: &Number) -> Result<()> {
         match master {
@@ -379,6 +390,13 @@ impl MergeStrategy<NumberContent, Number> for OptionalMergeStrategy {
             NumberContent::F32(f32_content) => {
                 if let Some(n) = value.as_f64() {
                     self.try_merge(f32_content, &(n as f32))
+                } else {
+                    todo!()
+                }
+            }
+            NumberContent::I8(i8_content) => {
+                if let Some(n) = value.as_i64() {
+                    self.try_merge(i8_content, &(n as i8))
                 } else {
                     todo!()
                 }

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -88,7 +88,7 @@ impl SqlxDataSource for MySqlDataSource {
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content> {
         let content = match column_info.data_type.to_lowercase().as_str() {
-            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" | "mediumtext" => {
+            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" | "mediumtext" | "blob" => {
                 let pattern = "[a-zA-Z0-9]{0, {}}".replace(
                     "{}",
                     &format!("{}", column_info.character_maximum_length.unwrap_or(1)),

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -88,7 +88,7 @@ impl SqlxDataSource for MySqlDataSource {
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content> {
         let content = match column_info.data_type.to_lowercase().as_str() {
-            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" => {
+            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" | "mediumtext" => {
                 let pattern = "[a-zA-Z0-9]{0, {}}".replace(
                     "{}",
                     &format!("{}", column_info.character_maximum_length.unwrap_or(1)),

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -97,12 +97,6 @@ impl SqlxDataSource for MySqlDataSource {
                     RegexContent::pattern(pattern).context("pattern will always compile")?,
                 ))
             }
-        // "tinyint" => Value::Number(Number::from(row.try_get::<i8, &str>(column.name())?)),
-        // "smallint" => Value::Number(Number::from(row.try_get::<i16, &str>(column.name())?)),
-        // "mediumint" | "int" | "integer" => {
-        //     Value::Number(Number::from(row.try_get::<i32, &str>(column.name())?))
-        // }
-        // "bigint" => Value::Number(Number::from(row.try_get::<i64, &str>(column.name())?)),
             "int" | "integer" | "mediumint"  => {
                 Content::Number(NumberContent::I32(I32::Range(RangeStep::default())))
             }

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -10,7 +10,7 @@ use rust_decimal::Decimal;
 use sqlx::mysql::{MySqlColumn, MySqlPoolOptions, MySqlRow};
 use sqlx::{Column, MySql, Pool, Row, TypeInfo};
 use std::collections::BTreeMap;
-use synth_core::schema::number_content::{F64, I8, I16, I32, I64, U64};
+use synth_core::schema::number_content::{F64, I16, I32, I64, I8, U64};
 use synth_core::schema::{
     ChronoValueType, DateTimeContent, NumberContent, RangeStep, RegexContent, StringContent,
 };
@@ -88,7 +88,8 @@ impl SqlxDataSource for MySqlDataSource {
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content> {
         let content = match column_info.data_type.to_lowercase().as_str() {
-            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" | "mediumtext" | "blob" => {
+            "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set"
+            | "mediumtext" | "blob" => {
                 let pattern = "[a-zA-Z0-9]{0, {}}".replace(
                     "{}",
                     &format!("{}", column_info.character_maximum_length.unwrap_or(1)),
@@ -97,18 +98,12 @@ impl SqlxDataSource for MySqlDataSource {
                     RegexContent::pattern(pattern).context("pattern will always compile")?,
                 ))
             }
-            "int" | "integer" | "mediumint"  => {
+            "int" | "integer" | "mediumint" => {
                 Content::Number(NumberContent::I32(I32::Range(RangeStep::default())))
             }
-            "tinyint" => {
-                Content::Number(NumberContent::I8(I8::Range(RangeStep::default())))
-            }
-            "smallint" => {
-                Content::Number(NumberContent::I16(I16::Range(RangeStep::default())))
-            }
-            "bigint" => {
-                Content::Number(NumberContent::I64(I64::Range(RangeStep::default())))
-            }
+            "tinyint" => Content::Number(NumberContent::I8(I8::Range(RangeStep::default()))),
+            "smallint" => Content::Number(NumberContent::I16(I16::Range(RangeStep::default()))),
+            "bigint" => Content::Number(NumberContent::I64(I64::Range(RangeStep::default()))),
             "serial" => Content::Number(NumberContent::U64(U64::Range(RangeStep::default()))),
             "float" | "double" | "numeric" | "decimal" => {
                 Content::Number(NumberContent::F64(F64::Range(RangeStep::default())))

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -10,7 +10,7 @@ use rust_decimal::Decimal;
 use sqlx::mysql::{MySqlColumn, MySqlPoolOptions, MySqlRow};
 use sqlx::{Column, MySql, Pool, Row, TypeInfo};
 use std::collections::BTreeMap;
-use synth_core::schema::number_content::{F64, I64, U64};
+use synth_core::schema::number_content::{F64, I8, I16, I32, I64, U64};
 use synth_core::schema::{
     ChronoValueType, DateTimeContent, NumberContent, RangeStep, RegexContent, StringContent,
 };
@@ -97,7 +97,22 @@ impl SqlxDataSource for MySqlDataSource {
                     RegexContent::pattern(pattern).context("pattern will always compile")?,
                 ))
             }
-            "int" | "integer" | "tinyint" | "smallint" | "mediumint" | "bigint" => {
+        // "tinyint" => Value::Number(Number::from(row.try_get::<i8, &str>(column.name())?)),
+        // "smallint" => Value::Number(Number::from(row.try_get::<i16, &str>(column.name())?)),
+        // "mediumint" | "int" | "integer" => {
+        //     Value::Number(Number::from(row.try_get::<i32, &str>(column.name())?))
+        // }
+        // "bigint" => Value::Number(Number::from(row.try_get::<i64, &str>(column.name())?)),
+            "int" | "integer" | "mediumint"  => {
+                Content::Number(NumberContent::I32(I32::Range(RangeStep::default())))
+            }
+            "tinyint" => {
+                Content::Number(NumberContent::I8(I8::Range(RangeStep::default())))
+            }
+            "smallint" => {
+                Content::Number(NumberContent::I16(I16::Range(RangeStep::default())))
+            }
+            "bigint" => {
                 Content::Number(NumberContent::I64(I64::Range(RangeStep::default())))
             }
             "serial" => Content::Number(NumberContent::U64(U64::Range(RangeStep::default()))),

--- a/synth/testing_harness/mysql/0_hospital_schema.sql
+++ b/synth/testing_harness/mysql/0_hospital_schema.sql
@@ -27,5 +27,6 @@ create table patients
     date_joined date,
     address     varchar(255),
     phone       varchar(20),
-    ssn         varchar(12)
+    ssn         varchar(12),
+    freckles    tinyint
 );

--- a/synth/testing_harness/mysql/1_hospital_data.sql
+++ b/synth/testing_harness/mysql/1_hospital_data.sql
@@ -43,80 +43,80 @@ INSERT INTO doctors (id,hospital_id,name,date_joined) VALUES
 
 -- Patients
 
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(1,1,'Thomas Dixon','2010-02-24','Studio 6\nCross lock\nEmilyside\nS2E 5RY','(0114)4960562','145-94-5022'),
-(2,2,'Anthony Morales','2013-07-06','Flat 52D\nAkhtar overpass\nNew Bernardshire\nLN8 1RE','+441154960433','812-01-4209'),
-(3,3,'Curtis West','2010-05-06','6 Fox roads\nSouth Martynchester\nHS3W 1TT','(0116) 496 0076','548-03-1303'),
-(4,1,'Nicholas Ryan','2010-10-31','90 Grace radial\nEast Terenceside\nRH87 6GH','(028) 9018 0291','504-87-6136'),
-(5,2,'Kristy Rodriguez','2017-08-27','035 Oliver forks\nThompsonborough\nB6 2NE','(0808)1570377','689-22-2477'),
-(6,3,'Tracy Pacheco','2011-12-28','Studio 52\nDorothy tunnel\nMartinstad\nRH69 3AA','(0121)4960038','431-83-7953'),
-(7,1,'Tracy Stevens','2010-10-17','Flat 74\nAndrew manor\nDianaland\nMK5A 2ZT','01632 960167','552-39-8225'),
-(8,2,'Thomas Scott','2012-01-04','Flat 26q\nPowell manor\nBarrymouth\nM2 0QU','01184960712','151-56-5875'),
-(9,3,'Tammy Charles','2013-10-23','798 Jenkins harbor\nNorth Jeremy\nIG49 7YS','+44161 496 0324','474-29-4412'),
-(10,1,'Jeanette Nichols','2010-04-06','3 Valerie tunnel\nNorth Colin\nSA2N 2QR','+44113 496 0050','378-64-1750');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(11,4,'Brett White','2010-11-13','Studio 31\nHughes mountains\nEast Norman\nTS23 7JW','+44909 8790083','548-42-7713'),
-(12,5,'Raymond Rodriguez','2017-06-10','Studio 23a\nSam turnpike\nEmmaview\nOX3P 1DN','+44(0)909 8790659','079-84-1510'),
-(13,6,'Lisa Johnson','2018-12-12','Flat 7\nRachel hill\nJenniferfurt\nG2 0QD','(0161)4960608','865-55-3656'),
-(14,4,'Christopher Gilbert','2010-12-29','Studio 0\nJulie motorway\nWatersville\nEN98 4SJ','(0808)1570048','121-28-3435'),
-(15,5,'Dr. Evan Garcia','2012-02-11','688 Glenn cliff\nAmberton\nN0 4PZ','(0161) 4960368','159-49-5330'),
-(16,6,'Christine Phillips','2012-07-06','2 Damian lights\nReecemouth\nMK15 1JQ','+44(0)117 4960500','725-75-1763'),
-(17,4,'Joseph Stone','2011-12-10','203 Rachael union\nJeanmouth\nG07 8DA','+44121 4960898','839-95-0445'),
-(18,5,'Donald Ford','2013-12-29','064 Glover forges\nNorth Philipport\nL88 8QU','01144960306','197-85-6864'),
-(19,6,'Robert Mayer','2017-03-30','Studio 91n\nLambert squares\nBrownside\nB6 9YP','01174960906','696-18-2664'),
-(20,4,'Deborah Watkins','2011-01-19','0 Paul port\nNorth Benjamin\nL7 0ZX','+44117 4960736','862-01-7079');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(21,7,'Hannah Kelly','2018-01-17','66 Billy turnpike\nNorth Melissa\nAL34 2RG','(0113) 4960268','388-46-1305'),
-(22,8,'Jesus Davis','2014-11-28','0 Taylor path\nNorth Judithville\nSY6 8SA','+44116 496 0687','020-44-4656'),
-(23,9,'Tammy Green','2015-08-06','5 Thomas mountain\nSouth Callumland\nE9C 0LQ','+44306 999 0527','086-87-2967'),
-(24,7,'Gina Hunt','2014-09-15','59 Gordon bridge\nPort Sandraberg\nWS8A 2AS','0151 496 0045','449-82-8506'),
-(25,8,'Brittany Matthews','2012-09-06','1 Walker station\nEast Alanfurt\nIP7 1QN','0141 496 0206','310-40-7955'),
-(26,9,'Jason Miller','2011-05-16','Studio 91e\nSheila field\nParkerbury\nLU1 3BP','+44(0)115 496 0265','197-90-4619'),
-(27,7,'Victoria Phillips','2014-11-13','47 Mason highway\nLake Andreaview\nTS1E 3XQ','+44(0)114 4960023','276-80-3097'),
-(28,8,'Robin Fowler','2019-04-19','Flat 8\nHeather ridge\nJessicahaven\nGL9R 7SX','+44(0)131 496 0765','544-59-7500'),
-(29,9,'Gregory Valencia','2016-02-19','090 Dunn shoal\nEast Katyville\nL9J 9GQ','+44(0)118 4960683','477-72-8246'),
-(30,7,'Maria Fletcher','2017-09-12','Flat 53\nRachael station\nNew Jemma\nE0 1JD','+4428 9018615','591-54-6181');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(31,10,'Jennifer Medina','2017-07-12','0 Murphy track\nJohnsonmouth\nW8W 8GZ','01164960054','172-54-0780'),
-(32,11,'Mr. Brian Porter','2016-10-29','Flat 4\nRice camp\nGoodwinview\nW20 5XZ','01164960868','179-79-1760'),
-(33,12,'Mark Young','2011-03-16','Flat 75\nCarol radial\nNorth Valerie\nHX62 6QA','(0114) 4960210','579-70-1181'),
-(34,10,'Michael Nicholson','2017-11-16','53 Nicole camp\nGeoffreyside\nNN3H 1FH','(0141) 4960237','155-92-3714'),
-(35,11,'George Mcguire','2013-11-07','189 Gould overpass\nCookefurt\nHD9 9RF','+44141 4960493','113-40-5786'),
-(36,12,'Karen Watkins','2019-11-21','76 Carol view\nNew Stephanie\nRH7H 0FQ','+441314960135','567-67-7368'),
-(37,10,'Stephanie Gamble','2014-08-09','97 Ann flats\nEast Charleneside\nWC7 1HT','+44121 4960213','250-03-1755'),
-(38,11,'Kim Meyers','2018-11-26','409 Butcher light\nLake Victoriafort\nB65 5FE','(0117)4960932','739-57-9547'),
-(39,12,'Ashley Harris','2012-05-19','06 Matthews mews\nWoodshire\nUB82 1JY','+44(0)121 4960110','723-90-8396'),
-(40,10,'Justin Kim','2010-11-20','Flat 25\nLisa inlet\nPort Ritafurt\nHS41 5ER','+44(0)118 496 0663','823-58-6236');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(41,13,'Mrs. Kristin Lewis DVM','2010-12-25','00 Barnes wells\nNew Sian\nS00 8YR','(020) 74960924','156-29-6887'),
-(42,14,'Janet Fernandez','2016-11-29','Flat 79\nNorman run\nSharonmouth\nB4U 7BL','+44(0)115 496 0126','460-18-0819'),
-(43,15,'Leslie Casey','2018-05-19','66 Smith expressway\nNormantown\nL1 5WR','+44(0)306 999 0764','067-93-6633'),
-(44,13,'Samantha Wright','2015-02-03','629 Burton gateway\nHughville\nS9 3LJ','0118 4960244','738-95-0807'),
-(45,14,'Brett Miller','2018-04-11','436 Graham hill\nShirleyborough\nPL5Y 3LD','0141 496 0793','726-38-6007'),
-(46,15,'Jason Crane','2017-04-26','Flat 99\nYoung fall\nAliceton\nB0S 2AT','+44(0)1174960479','833-04-0115'),
-(47,13,'Madison Yoder','2015-03-23','062 Katy landing\nPhillipsview\nSS91 9YP','01184960060','006-10-0679'),
-(48,14,'Michael Sellers','2019-10-28','142 Stephen junction\nBennettfurt\nW2W 9BD','+44(0)8081570284','472-17-6148'),
-(49,15,'Rebecca Brown','2011-10-20','Flat 64\nDennis throughway\nEast Benjaminland\nDT37 3FL','(0117) 4960069','233-17-3594'),
-(50,13,'Cody Bryant','2015-08-23','Studio 5\nLewis hollow\nEdwardsland\nS96 4TG','+44115 496 0334','649-23-3293');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(51,16,'Kevin Payne','2019-03-24','Studio 8\nBethan stream\nNew Elliottshire\nSL7H 0SS','+441314960539','585-82-2591'),
-(52,17,'Megan Ryan','2016-04-21','Flat 6\nHenry inlet\nWest Samantha\nHS7N 9FT','+44(0)116 4960007','698-18-1758'),
-(53,18,'Matthew Henry','2018-10-20','743 Shaw knoll\nLeeside\nM01 3HY','01154960297','775-07-6124'),
-(54,16,'Noah Chandler','2013-03-31','Studio 73\nBell loaf\nAlitown\nCA0 8AY','+44121 4960245','761-56-1725'),
-(55,17,'Garrett Fowler','2011-07-17','Flat 23A\nMitchell squares\nHoltchester\nE23 9WJ','+441632 960 338','859-35-9693'),
-(56,18,'Spencer Campbell','2013-06-16','915 Mason bridge\nSouth Patriciachester\nDA61 0ZN','+44(0)808 157 0553','363-69-2489'),
-(57,16,'Robert Becker','2018-11-27','900 Boyle forest\nPort Andrewburgh\nM6 2HT','(020) 7496 0080','788-71-1402'),
-(58,17,'Matthew Murillo','2015-03-01','Studio 30\nHughes river\nWhitemouth\nS10 0LN','02074960325','330-99-9498'),
-(59,18,'Brandy Hernandez','2018-05-27','Flat 3\nAntony forges\nLake Eric\nPO0 8UP','09098790239','803-29-7495'),
-(60,16,'Jamie Sutton','2010-11-19','927 Gibbs cliff\nGregoryshire\nUB6H 9XQ','+44(0)29 2018479','645-23-9803');
-INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn) VALUES
-(61,19,'Renee Robertson','2019-07-24','0 Jodie pike\nEast Alan\nBH7Y 2WN','(0115) 4960107','787-06-1801'),
-(62,20,'Rachel Nelson','2012-01-11','Studio 6\nAdam lodge\nNew Maureen\nG4W 3UN','0131 4960314','829-19-7394'),
-(63,21,'Melissa Silva','2019-05-09','Studio 58\nGreen shore\nNorth Shauntown\nS54 5NY','(0121) 4960580','321-13-7363'),
-(64,19,'Frank Bradley','2012-09-08','9 Sandra avenue\nJaniceville\nM1 0JP','(0161) 496 0548','187-91-0569'),
-(65,20,'Stephen Briggs','2010-03-29','Flat 82\nQuinn parkways\nEast Joyceland\nG2 2TX','029 2018 0186','231-59-8966'),
-(66,21,'Emily Camacho','2016-12-26','093 Marshall plains\nEast Mathewfort\nKY3 5WU','+44(0)909 8790988','534-62-0149'),
-(67,19,'Ryan Cain','2017-11-18','8 Dawn glens\nLouiseburgh\nE1W 0LH','(0141)4960552','518-81-2366'),
-(68,20,'Daniel Thornton','2017-01-16','01 Lisa cliff\nSmithmouth\nOX92 5ZQ','01414960391','511-66-0104'),
-(69,21,'Kyle Pacheco','2018-06-26','754 Thompson lodge\nThomashaven\nDH41 3JW','(028) 9018567','008-70-2086'),
-(70,19,'Scott Nielsen','2016-10-15','Studio 74y\nBeth path\nMooreburgh\nE2 9ZB','(0808)1570400','823-56-1410');
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(1,1,'Thomas Dixon','2010-02-24','Studio 6\nCross lock\nEmilyside\nS2E 5RY','(0114)4960562','145-94-5022',69),
+(2,2,'Anthony Morales','2013-07-06','Flat 52D\nAkhtar overpass\nNew Bernardshire\nLN8 1RE','+441154960433','812-01-4209',78),
+(3,3,'Curtis West','2010-05-06','6 Fox roads\nSouth Martynchester\nHS3W 1TT','(0116) 496 0076','548-03-1303',-122),
+(4,1,'Nicholas Ryan','2010-10-31','90 Grace radial\nEast Terenceside\nRH87 6GH','(028) 9018 0291','504-87-6136',43),
+(5,2,'Kristy Rodriguez','2017-08-27','035 Oliver forks\nThompsonborough\nB6 2NE','(0808)1570377','689-22-2477',20),
+(6,3,'Tracy Pacheco','2011-12-28','Studio 52\nDorothy tunnel\nMartinstad\nRH69 3AA','(0121)4960038','431-83-7953',94),
+(7,1,'Tracy Stevens','2010-10-17','Flat 74\nAndrew manor\nDianaland\nMK5A 2ZT','01632 960167','552-39-8225',-62),
+(8,2,'Thomas Scott','2012-01-04','Flat 26q\nPowell manor\nBarrymouth\nM2 0QU','01184960712','151-56-5875',-97),
+(9,3,'Tammy Charles','2013-10-23','798 Jenkins harbor\nNorth Jeremy\nIG49 7YS','+44161 496 0324','474-29-4412',68),
+(10,1,'Jeanette Nichols','2010-04-06','3 Valerie tunnel\nNorth Colin\nSA2N 2QR','+44113 496 0050','378-64-1750',-111);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(11,4,'Brett White','2010-11-13','Studio 31\nHughes mountains\nEast Norman\nTS23 7JW','+44909 8790083','548-42-7713',73),
+(12,5,'Raymond Rodriguez','2017-06-10','Studio 23a\nSam turnpike\nEmmaview\nOX3P 1DN','+44(0)909 8790659','079-84-1510',74),
+(13,6,'Lisa Johnson','2018-12-12','Flat 7\nRachel hill\nJenniferfurt\nG2 0QD','(0161)4960608','865-55-3656',29),
+(14,4,'Christopher Gilbert','2010-12-29','Studio 0\nJulie motorway\nWatersville\nEN98 4SJ','(0808)1570048','121-28-3435',63),
+(15,5,'Dr. Evan Garcia','2012-02-11','688 Glenn cliff\nAmberton\nN0 4PZ','(0161) 4960368','159-49-5330',7),
+(16,6,'Christine Phillips','2012-07-06','2 Damian lights\nReecemouth\nMK15 1JQ','+44(0)117 4960500','725-75-1763',119),
+(17,4,'Joseph Stone','2011-12-10','203 Rachael union\nJeanmouth\nG07 8DA','+44121 4960898','839-95-0445',88),
+(18,5,'Donald Ford','2013-12-29','064 Glover forges\nNorth Philipport\nL88 8QU','01144960306','197-85-6864',126),
+(19,6,'Robert Mayer','2017-03-30','Studio 91n\nLambert squares\nBrownside\nB6 9YP','01174960906','696-18-2664',-56),
+(20,4,'Deborah Watkins','2011-01-19','0 Paul port\nNorth Benjamin\nL7 0ZX','+44117 4960736','862-01-7079',-93);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(21,7,'Hannah Kelly','2018-01-17','66 Billy turnpike\nNorth Melissa\nAL34 2RG','(0113) 4960268','388-46-1305',-100),
+(22,8,'Jesus Davis','2014-11-28','0 Taylor path\nNorth Judithville\nSY6 8SA','+44116 496 0687','020-44-4656',124),
+(23,9,'Tammy Green','2015-08-06','5 Thomas mountain\nSouth Callumland\nE9C 0LQ','+44306 999 0527','086-87-2967',118),
+(24,7,'Gina Hunt','2014-09-15','59 Gordon bridge\nPort Sandraberg\nWS8A 2AS','0151 496 0045','449-82-8506',-76),
+(25,8,'Brittany Matthews','2012-09-06','1 Walker station\nEast Alanfurt\nIP7 1QN','0141 496 0206','310-40-7955',-116),
+(26,9,'Jason Miller','2011-05-16','Studio 91e\nSheila field\nParkerbury\nLU1 3BP','+44(0)115 496 0265','197-90-4619',-19),
+(27,7,'Victoria Phillips','2014-11-13','47 Mason highway\nLake Andreaview\nTS1E 3XQ','+44(0)114 4960023','276-80-3097',-20),
+(28,8,'Robin Fowler','2019-04-19','Flat 8\nHeather ridge\nJessicahaven\nGL9R 7SX','+44(0)131 496 0765','544-59-7500',38),
+(29,9,'Gregory Valencia','2016-02-19','090 Dunn shoal\nEast Katyville\nL9J 9GQ','+44(0)118 4960683','477-72-8246',-11),
+(30,7,'Maria Fletcher','2017-09-12','Flat 53\nRachael station\nNew Jemma\nE0 1JD','+4428 9018615','591-54-6181',-80);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(31,10,'Jennifer Medina','2017-07-12','0 Murphy track\nJohnsonmouth\nW8W 8GZ','01164960054','172-54-0780',125),
+(32,11,'Mr. Brian Porter','2016-10-29','Flat 4\nRice camp\nGoodwinview\nW20 5XZ','01164960868','179-79-1760',-71),
+(33,12,'Mark Young','2011-03-16','Flat 75\nCarol radial\nNorth Valerie\nHX62 6QA','(0114) 4960210','579-70-1181',-27),
+(34,10,'Michael Nicholson','2017-11-16','53 Nicole camp\nGeoffreyside\nNN3H 1FH','(0141) 4960237','155-92-3714',14),
+(35,11,'George Mcguire','2013-11-07','189 Gould overpass\nCookefurt\nHD9 9RF','+44141 4960493','113-40-5786',46),
+(36,12,'Karen Watkins','2019-11-21','76 Carol view\nNew Stephanie\nRH7H 0FQ','+441314960135','567-67-7368',-89),
+(37,10,'Stephanie Gamble','2014-08-09','97 Ann flats\nEast Charleneside\nWC7 1HT','+44121 4960213','250-03-1755',55),
+(38,11,'Kim Meyers','2018-11-26','409 Butcher light\nLake Victoriafort\nB65 5FE','(0117)4960932','739-57-9547',85),
+(39,12,'Ashley Harris','2012-05-19','06 Matthews mews\nWoodshire\nUB82 1JY','+44(0)121 4960110','723-90-8396',-10),
+(40,10,'Justin Kim','2010-11-20','Flat 25\nLisa inlet\nPort Ritafurt\nHS41 5ER','+44(0)118 496 0663','823-58-6236',-76);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(41,13,'Mrs. Kristin Lewis DVM','2010-12-25','00 Barnes wells\nNew Sian\nS00 8YR','(020) 74960924','156-29-6887',0),
+(42,14,'Janet Fernandez','2016-11-29','Flat 79\nNorman run\nSharonmouth\nB4U 7BL','+44(0)115 496 0126','460-18-0819',96),
+(43,15,'Leslie Casey','2018-05-19','66 Smith expressway\nNormantown\nL1 5WR','+44(0)306 999 0764','067-93-6633',34),
+(44,13,'Samantha Wright','2015-02-03','629 Burton gateway\nHughville\nS9 3LJ','0118 4960244','738-95-0807',62),
+(45,14,'Brett Miller','2018-04-11','436 Graham hill\nShirleyborough\nPL5Y 3LD','0141 496 0793','726-38-6007',-6),
+(46,15,'Jason Crane','2017-04-26','Flat 99\nYoung fall\nAliceton\nB0S 2AT','+44(0)1174960479','833-04-0115',-41),
+(47,13,'Madison Yoder','2015-03-23','062 Katy landing\nPhillipsview\nSS91 9YP','01184960060','006-10-0679',95),
+(48,14,'Michael Sellers','2019-10-28','142 Stephen junction\nBennettfurt\nW2W 9BD','+44(0)8081570284','472-17-6148',74),
+(49,15,'Rebecca Brown','2011-10-20','Flat 64\nDennis throughway\nEast Benjaminland\nDT37 3FL','(0117) 4960069','233-17-3594',94),
+(50,13,'Cody Bryant','2015-08-23','Studio 5\nLewis hollow\nEdwardsland\nS96 4TG','+44115 496 0334','649-23-3293',58);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(51,16,'Kevin Payne','2019-03-24','Studio 8\nBethan stream\nNew Elliottshire\nSL7H 0SS','+441314960539','585-82-2591',107),
+(52,17,'Megan Ryan','2016-04-21','Flat 6\nHenry inlet\nWest Samantha\nHS7N 9FT','+44(0)116 4960007','698-18-1758',123),
+(53,18,'Matthew Henry','2018-10-20','743 Shaw knoll\nLeeside\nM01 3HY','01154960297','775-07-6124',-87),
+(54,16,'Noah Chandler','2013-03-31','Studio 73\nBell loaf\nAlitown\nCA0 8AY','+44121 4960245','761-56-1725',-73),
+(55,17,'Garrett Fowler','2011-07-17','Flat 23A\nMitchell squares\nHoltchester\nE23 9WJ','+441632 960 338','859-35-9693',-17),
+(56,18,'Spencer Campbell','2013-06-16','915 Mason bridge\nSouth Patriciachester\nDA61 0ZN','+44(0)808 157 0553','363-69-2489',121),
+(57,16,'Robert Becker','2018-11-27','900 Boyle forest\nPort Andrewburgh\nM6 2HT','(020) 7496 0080','788-71-1402',-53),
+(58,17,'Matthew Murillo','2015-03-01','Studio 30\nHughes river\nWhitemouth\nS10 0LN','02074960325','330-99-9498',105),
+(59,18,'Brandy Hernandez','2018-05-27','Flat 3\nAntony forges\nLake Eric\nPO0 8UP','09098790239','803-29-7495',-30),
+(60,16,'Jamie Sutton','2010-11-19','927 Gibbs cliff\nGregoryshire\nUB6H 9XQ','+44(0)29 2018479','645-23-9803',44);
+INSERT INTO patients (id,doctor_id,name,date_joined,address,phone,ssn,freckles) VALUES
+(61,19,'Renee Robertson','2019-07-24','0 Jodie pike\nEast Alan\nBH7Y 2WN','(0115) 4960107','787-06-1801',-125),
+(62,20,'Rachel Nelson','2012-01-11','Studio 6\nAdam lodge\nNew Maureen\nG4W 3UN','0131 4960314','829-19-7394',80),
+(63,21,'Melissa Silva','2019-05-09','Studio 58\nGreen shore\nNorth Shauntown\nS54 5NY','(0121) 4960580','321-13-7363',-111),
+(64,19,'Frank Bradley','2012-09-08','9 Sandra avenue\nJaniceville\nM1 0JP','(0161) 496 0548','187-91-0569',90),
+(65,20,'Stephen Briggs','2010-03-29','Flat 82\nQuinn parkways\nEast Joyceland\nG2 2TX','029 2018 0186','231-59-8966',29),
+(66,21,'Emily Camacho','2016-12-26','093 Marshall plains\nEast Mathewfort\nKY3 5WU','+44(0)909 8790988','534-62-0149',50),
+(67,19,'Ryan Cain','2017-11-18','8 Dawn glens\nLouiseburgh\nE1W 0LH','(0141)4960552','518-81-2366',28),
+(68,20,'Daniel Thornton','2017-01-16','01 Lisa cliff\nSmithmouth\nOX92 5ZQ','01414960391','511-66-0104',43),
+(69,21,'Kyle Pacheco','2018-06-26','754 Thompson lodge\nThomashaven\nDH41 3JW','(028) 9018567','008-70-2086',72),
+(70,19,'Scott Nielsen','2016-10-15','Studio 74y\nBeth path\nMooreburgh\nE2 9ZB','(0808)1570400','823-56-1410',-46);

--- a/synth/testing_harness/mysql/README.md
+++ b/synth/testing_harness/mysql/README.md
@@ -1,11 +1,17 @@
 Integration Tests for MySql
 ====================================
 
-This is an integration test that validates the synth generate and synth import commands for MySql on a Debian flavored 
+This is an integration test that validates the synth generate and synth import commands for MySql on a Debian flavored
 OS. The models in hospital_master are used as a known "golden" set to validate against. The *.sql scripts generate the
 schema and test data within the database.
 
-# Requirements:
+## Note if running locally on Mac OS
+
+`./e2e.sh` assumes the use of the GNU variant of `grep`, specifically in its use of `-P` for PCRE flavored regex.
+You will need to run `brew install grep`, and then alter the script to use `ggrep` command instead of the built-in BSD `grep`.
+
+# Requirements
+
 - Docker
 - jq
 

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -85,7 +85,7 @@ function test-warning() {
 
   docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" <"$folder/schema.sql"
   output=$($SYNTH generate --size 10 --to mysql://root:${PASSWORD}@localhost:${PORT}/test_db "$folder" 2>&1)
-  warnings=$(echo "$output" | grep "WARN" | ggrep -Po "(?<=\]\s).*$")
+  warnings=$(echo "$output" | grep "WARN" | grep -Po "(?<=\]\s).*$")
 
   if [ -z "$warnings" ]; then
     echo -e "${ERROR}[$folder] did not produce any warnings${NC}"

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -3,14 +3,14 @@
 set -uo pipefail
 
 # load env vars
-if [ -f .env ]
-then
+if [ -f .env ]; then
   set -a
   . .env
   set +a
 fi
 
-SYNTH="synth"
+#SYNTH="synth"
+SYNTH="/Users/tomgoren/tmp/synth/target/debug/synth"
 [ "${CI-false}" == "true" ] || SYNTH="cargo run --quiet --bin synth"
 
 ERROR='\033[0;31m'
@@ -35,31 +35,45 @@ commands:
 }
 
 function load-schema() {
-  docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" < 0_hospital_schema.sql || return 1
-  [ ${1} == "--no-data" ] || docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" < 1_hospital_data.sql || return 1
+  docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" <0_hospital_schema.sql || return 1
+  [ ${1} == "--no-data" ] || docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" <1_hospital_data.sql || return 1
 }
 
 function test-generate() {
   echo -e "${INFO}Test generate${NC}"
-  load-schema --no-data || { echo -e "${ERROR}Failed to load schema${NC}"; return 1; }
+  load-schema --no-data || {
+    echo -e "${ERROR}Failed to load schema${NC}"
+    return 1
+  }
   $SYNTH generate hospital_master --to mysql://root:${PASSWORD}@localhost:${PORT}/test_db --size 30 || return 1
 
   sum_rows_query="SELECT (SELECT count(*) FROM hospitals) +  (SELECT count(*) FROM doctors) + (SELECT count(*) FROM patients)"
-  sum=`docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" -e "$sum_rows_query" | grep -o '[[:digit:]]*'`
-  [ "$sum" -gt "30" ] || { echo -e "${ERROR}Generation did not create more than 30 records${NC}"; return 1; }
+  sum=$(docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" -e "$sum_rows_query" | grep -o '[[:digit:]]*')
+  [ "$sum" -gt "30" ] || {
+    echo -e "${ERROR}Generation did not create more than 30 records${NC}"
+    return 1
+  }
 }
 
 function test-import() {
   echo -e "${INFO}Testing import${NC}"
-  load-schema --all || { echo -e "${ERROR}Failed to load schema${NC}"; return 1; }
-  $SYNTH import --from mysql://root:${PASSWORD}@localhost:${PORT}/test_db hospital_import || { echo -e "${ERROR}Import failed${NC}"; return 1; }
-  diff <(jq --sort-keys . hospital_import/*) <(jq --sort-keys . hospital_master/*) || { echo -e "${ERROR}Import namespaces do not match${NC}"; return 1; }
+  load-schema --all || {
+    echo -e "${ERROR}Failed to load schema${NC}"
+    return 1
+  }
+  $SYNTH import --from mysql://root:${PASSWORD}@localhost:${PORT}/test_db hospital_import || {
+    echo -e "${ERROR}Import failed${NC}"
+    return 1
+  }
+  diff <(jq --sort-keys . hospital_import/*) <(jq --sort-keys . hospital_master/*) || {
+    echo -e "${ERROR}Import namespaces do not match${NC}"
+    return 1
+  }
 }
 
 function test-warnings() {
   result=0
-  for d in warnings/*/
-  do
+  for d in warnings/*/; do
     test-warning $d || result=$?
   done
 }
@@ -69,18 +83,20 @@ function test-warning() {
 
   echo -e "${INFO}[$folder] Testing warning${NC}"
 
-  docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" < "$folder/schema.sql"
+  docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" <"$folder/schema.sql"
   output=$($SYNTH generate --size 10 --to mysql://root:${PASSWORD}@localhost:${PORT}/test_db "$folder" 2>&1)
-  warnings=$(echo "$output" | grep "WARN" | grep -Po "(?<=\]\s).*$")
+  warnings=$(echo "$output" | grep "WARN" | ggrep -Po "(?<=\]\s).*$")
 
-  if [ -z "$warnings" ]
-  then
+  if [ -z "$warnings" ]; then
     echo -e "${ERROR}[$folder] did not produce any warnings${NC}"
     echo -e "${DEBUG}$output${NC}"
     return 1
   fi
 
-  diff <(echo "$warnings") "$folder/warnings.txt" || { echo -e "${ERROR}[$folder] warnings do not match${NC}"; return 1; }
+  diff <(echo "$warnings") "$folder/warnings.txt" || {
+    echo -e "${ERROR}[$folder] warnings do not match${NC}"
+    return 1
+  }
 }
 
 function test-local() {
@@ -102,11 +118,10 @@ function test-local() {
 function up() {
   echo -e "${DEBUG}Starting container${NC}"
   echo -e "${DEBUG}Running database with container name $NAME on port $PORT with password $PASSWORD${NC}"
-  docker run --rm --name $NAME -p $PORT:3306 -e MYSQL_ROOT_PASSWORD=$PASSWORD -e MYSQL_DATABASE="test_db" -d $SCHEME > /dev/null
+  docker run --rm --name $NAME -p $PORT:3306 -e MYSQL_ROOT_PASSWORD=$PASSWORD -e MYSQL_DATABASE="test_db" -d $SCHEME >/dev/null
 
   wait_count=0
-  while ! docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" -e "SELECT 1" > /dev/null 2>&1
-  do
+  while ! docker exec -i $NAME $SCHEME -h 127.0.0.1 -u root --password=$PASSWORD -P 3306 "test_db" -e "SELECT 1" >/dev/null 2>&1; do
     range=$(printf "%${wait_count}s")
     echo -en "\\r${DEBUG}Waiting for DB to come up${range// /.}${NC}"
     wait_count=$((wait_count + 1))
@@ -117,8 +132,8 @@ function up() {
 
 function down() {
   echo -e "${DEBUG}Stopping container${NC}"
-  docker stop $NAME > /dev/null
-  docker rm $NAME > /dev/null
+  docker stop $NAME >/dev/null
+  docker rm $NAME >/dev/null
 }
 
 function cleanup() {
@@ -128,34 +143,35 @@ function cleanup() {
 }
 
 case "${1-*}" in
-  load-schema)
-    load-schema ${2---all} || exit 1
-    ;;
-  test-generate)
-    test-generate || exit 1
-    ;;
-  test-import)
-    test-import || exit 1
-    ;;
-  test-warnings)
-    test-warnings || exit 1
-    ;;
-  test-warning)
-    test-warning "warnings/$2" || exit 1
-    ;;
-  test-local)
-    test-local || exit 1
-    ;;
-  up)
-    up
-    ;;
-  down)
-    down
-    ;;
-  cleanup)
-    cleanup
-    ;;
-  *)
-    help $0
-    exit 1
+load-schema)
+  load-schema ${2---all} || exit 1
+  ;;
+test-generate)
+  test-generate || exit 1
+  ;;
+test-import)
+  test-import || exit 1
+  ;;
+test-warnings)
+  test-warnings || exit 1
+  ;;
+test-warning)
+  test-warning "warnings/$2" || exit 1
+  ;;
+test-local)
+  test-local || exit 1
+  ;;
+up)
+  up
+  ;;
+down)
+  down
+  ;;
+cleanup)
+  cleanup
+  ;;
+*)
+  help $0
+  exit 1
+  ;;
 esac

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -9,8 +9,7 @@ if [ -f .env ]; then
   set +a
 fi
 
-#SYNTH="synth"
-SYNTH="/Users/tomgoren/tmp/synth/target/debug/synth"
+SYNTH="synth"
 [ "${CI-false}" == "true" ] || SYNTH="cargo run --quiet --bin synth"
 
 ERROR='\033[0;31m'

--- a/synth/testing_harness/mysql/hospital_master/doctors.json
+++ b/synth/testing_harness/mysql/hospital_master/doctors.json
@@ -38,7 +38,7 @@
             "low": 1,
             "high": 14
           },
-          "subtype": "i64"
+          "subtype": "i32"
         },
         {
           "weight": 1.0,
@@ -49,7 +49,7 @@
     "id": {
       "type": "number",
       "id": {},
-      "subtype": "i64"
+      "subtype": "i32"
     },
     "name": {
       "type": "one_of",

--- a/synth/testing_harness/mysql/hospital_master/hospitals.json
+++ b/synth/testing_harness/mysql/hospital_master/hospitals.json
@@ -42,7 +42,7 @@
     "id": {
       "type": "number",
       "id": {},
-      "subtype": "i64"
+      "subtype": "i32"
     }
   }
 }

--- a/synth/testing_harness/mysql/hospital_master/patients.json
+++ b/synth/testing_harness/mysql/hospital_master/patients.json
@@ -52,7 +52,25 @@
             "low": 1,
             "high": 20
           },
-          "subtype": "i64"
+          "subtype": "i32"
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "freckles": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "number",
+          "range": {
+            "low": -93,
+            "high": 121
+          },
+          "subtype": "i8"
         },
         {
           "weight": 1.0,
@@ -63,7 +81,7 @@
     "id": {
       "type": "number",
       "id": {},
-      "subtype": "i64"
+      "subtype": "i32"
     },
     "name": {
       "type": "one_of",

--- a/synth/testing_harness/mysql/warnings/f64/warnings.txt
+++ b/synth/testing_harness/mysql/warnings/f64/warnings.txt
@@ -1,1 +1,1 @@
-Trying to put a f64 into a float typed column f32.float
+Trying to put a f64 into a float typed column f64.float


### PR DESCRIPTION
Hi friends!

Came across an issue when trying to `import` from a MySQL source on a schema that made use of `TINYINT` columns, and found a couple of other discrepancies with what I understood to be the type translation as [specified in the docs](https://www.getsynth.com/docs/integrations/mysql).

I am not very experienced in Rust, and I am primarily basing the work here on [prior art](https://github.com/shuttle-hq/synth/pull/405).

We'll probably want the following:
* Extend the test scenarios to the Postgres cases, and/or confirm that these changes don't break some changes somewhere
* Bump a version - I think these might be considered breaking changes somewhat
* Add support for `u8` as well?
  * This will also make the testing schema modification I made less nonsensical, I don't know what negative freckle count means 🤷 

Thank you!